### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/lib/src/main/java/it/cosenonjaviste/daggermock/ErrorsFormatter.java
+++ b/lib/src/main/java/it/cosenonjaviste/daggermock/ErrorsFormatter.java
@@ -19,6 +19,9 @@ package it.cosenonjaviste.daggermock;
 import java.util.Collection;
 
 class ErrorsFormatter {
+
+    private ErrorsFormatter() {}
+
     private static String message(String message1, Collection<String> errors, String message2) {
         StringBuilder b = new StringBuilder(message1).append(":");
         for (String error : errors) {

--- a/lib/src/main/java/it/cosenonjaviste/daggermock/ReflectUtils.java
+++ b/lib/src/main/java/it/cosenonjaviste/daggermock/ReflectUtils.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 class ReflectUtils {
+
+    private ReflectUtils() {}
+
     public static String toCamelCase(String str) {
         return str.substring(0, 1).toLowerCase() + str.substring(1);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed