### PR TITLE
Code quality fix - Methods should not return constants.

### DIFF
--- a/app/src/main/java/it/cosenonjaviste/daggermock/demo/RestService.java
+++ b/app/src/main/java/it/cosenonjaviste/daggermock/demo/RestService.java
@@ -17,7 +17,10 @@
 package it.cosenonjaviste.daggermock.demo;
 
 public class RestService {
+
+    public static final String MSG_HELLO_WORLD = "Hello world";
+
     public String getSomething() {
-        return "Hello world";
+        return MSG_HELLO_WORLD;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/dependency/MyService.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/dependency/MyService.java
@@ -17,7 +17,10 @@
 package it.cosenonjaviste.daggermock.dependency;
 
 public class MyService {
+
+    public static final String MSG_AAA = "AAA";
+
     public String get() {
-        return "AAA";
+        return MSG_AAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/dependency/MyService2.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/dependency/MyService2.java
@@ -17,7 +17,10 @@
 package it.cosenonjaviste.daggermock.dependency;
 
 public class MyService2 {
+
+    public static final String MSG_AAA = "AAA";
+
     public String get() {
-        return "AAA";
+        return MSG_AAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/errorwhenoverrideinject/MyService.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/errorwhenoverrideinject/MyService.java
@@ -17,7 +17,10 @@
 package it.cosenonjaviste.daggermock.errorwhenoverrideinject;
 
 public class MyService {
+
+    public static final String MSG_AAA = "AAA";
+
     public String get() {
-        return "AAA";
+        return MSG_AAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/errorwhenoverrideinject/MyService2.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/errorwhenoverrideinject/MyService2.java
@@ -20,11 +20,13 @@ import javax.inject.Inject;
 
 public class MyService2 {
 
+    public static final String MSG_BBB = "BBB";
+
     @Inject
     public MyService2() {
     }
 
     public String get() {
-        return "BBB";
+        return MSG_BBB;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponent/InjectFromComponentTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponent/InjectFromComponentTest.java
@@ -42,8 +42,11 @@ public class InjectFromComponentTest {
 
     @Module
     public static class MyModule {
+
+        public static final String MSG_S1 = "s1";
+
         @Provides public String provideS1() {
-            return "s1";
+            return MSG_S1;
         }
     }
 

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponentwithparams/InjectFromComponentWithMultipleParametersTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponentwithparams/InjectFromComponentWithMultipleParametersTest.java
@@ -43,9 +43,12 @@ public class InjectFromComponentWithMultipleParametersTest {
 
     @Module
     public static class MyModule {
+
+        public static final String MSG_S1 = "s1";
+
         @Provides
         public String provideS1() {
-            return "s1";
+            return MSG_S1;
         }
     }
 

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponentwithparams/InjectFromComponentWithSingleParameterTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromcomponentwithparams/InjectFromComponentWithSingleParameterTest.java
@@ -43,9 +43,12 @@ public class InjectFromComponentWithSingleParameterTest {
 
     @Module
     public static class MyModule {
+
+        public static final String MSG_S1 = "s1";
+
         @Provides
         public String provideS1() {
-            return "s1";
+            return MSG_S1;
         }
     }
 

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromsubcomponent/InjectFromSubComponentNoParams.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/injectfromsubcomponent/InjectFromSubComponentNoParams.java
@@ -44,9 +44,12 @@ public class InjectFromSubComponentNoParams {
 
     @Module
     public static class MyModule {
+
+        public static final String MSG_S1 = "s1";
+
         @Provides
         public String provideS1() {
-            return "s1";
+            return MSG_S1;
         }
     }
 

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/named/NamedTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/named/NamedTest.java
@@ -49,12 +49,16 @@ public class NamedTest {
 
     @Module
     public static class MyModule {
+
+        public static final String MSG_S1 = "s1";
+        public static final String MSG_S2 = "s2";
+
         @Provides @Named("s1") public String provideS1() {
-            return "s1";
+            return MSG_S1;
         }
 
         @Provides @Named("s2") public String provideS2() {
-            return "s2";
+            return MSG_S2;
         }
     }
 

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/simple/MyService.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/simple/MyService.java
@@ -17,8 +17,11 @@
 package it.cosenonjaviste.daggermock.simple;
 
 public class MyService {
+
+    public static final String MSG_AAA = "AAA";
+
     public String get() {
-        return "AAA";
+        return MSG_AAA;
     }
 
     public String getWithParam(int param) {

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/simple/MyService2.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/simple/MyService2.java
@@ -17,7 +17,10 @@
 package it.cosenonjaviste.daggermock.simple;
 
 public class MyService2 {
+
+    public static final String MSG_AAA = "AAA";
+
     public String get() {
-        return "AAA";
+        return MSG_AAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponent/MyModule.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponent/MyModule.java
@@ -21,7 +21,10 @@ import dagger.Provides;
 
 @Module
 public class MyModule {
+
+    public static final String MSG_AAAA = "AAAA";
+
     @Provides public String provideMyString() {
-        return "AAAA";
+        return MSG_AAAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponent/MySubModule.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponent/MySubModule.java
@@ -5,6 +5,7 @@ import dagger.Provides;
 
 @Module
 public class MySubModule {
+    public static final int CONST_MY_INT = 12345;
 
 //    private String param;
 //
@@ -14,6 +15,6 @@ public class MySubModule {
 
     @Provides
     public Integer provideMyInteger() {
-        return 12345;
+        return CONST_MY_INT;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MyModule.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MyModule.java
@@ -21,7 +21,10 @@ import dagger.Provides;
 
 @Module
 public class MyModule {
+
+    public static final String MSG_AAAA = "AAAA";
+
     @Provides public String provideMyString() {
-        return "AAAA";
+        return MSG_AAAA;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule.java
@@ -6,8 +6,10 @@ import dagger.Provides;
 @Module
 public class MySubModule {
 
+    public static final int CONST_MY_INT = 12345;
+
     @Provides
     public Integer provideMyInteger() {
-        return 12345;
+        return CONST_MY_INT;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule2.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule2.java
@@ -6,8 +6,10 @@ import dagger.Provides;
 @Module
 public class MySubModule2 {
 
+    public static final long CONST_MY_LONG = 12345678L;
+
     @Provides
     public Long provideMyLong() {
-        return 12345678L;
+        return CONST_MY_LONG;
     }
 }

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule3.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/subcomponenterror/MySubModule3.java
@@ -6,8 +6,10 @@ import dagger.Provides;
 @Module
 public class MySubModule3 {
 
+    public static final int CONST_MY_INT = 2345;
+
     @Provides
     public Short provideMyShort() {
-        return 2345;
+        return CONST_MY_INT;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S3400 - Methods should not return constants
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S3400

Please let me know if you have any questions.

Faisal Hameed