### PR TITLE
Update to gradlew 2.14 and build tools 2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 30 16:13:07 CET 2016
+#Mon Sep 12 15:03:15 CDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
This pull request is targeted at updating the gradle wrapper and the build tools to newer version. The project still does not compile as other dependencies are out of date and no longer available from their current location; that will be addressed in a subsequent pull request. More information about the gradlew wrapper updates can be found here: 

https://docs.gradle.org/2.14.1/release-notes
https://developer.android.com/studio/releases/gradle-plugin.html#revisions