### PR TITLE
Update libraries, move common dependencies versions to project file

### DIFF
--- a/RealWorldApp/build.gradle
+++ b/RealWorldApp/build.gradle
@@ -53,13 +53,13 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:design:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:design:24.2.1'
 
-    compile 'com.google.dagger:dagger:2.6.1'
+    compile "com.google.dagger:dagger:$DAGGER_VERSION"
     compile 'javax.annotation:jsr250-api:1.0'
-    apt 'com.google.dagger:dagger-compiler:2.6.1'
-    testCompile 'com.google.dagger:dagger-compiler:2.6.1'
+    apt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
+    testCompile "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
 
     testCompile project(':lib')
     androidTestCompile project(':lib')
@@ -67,14 +67,14 @@ dependencies {
     testCompile "org.robolectric:robolectric:3.0"
     testCompile 'org.assertj:assertj-core:2.5.0'
 
-    androidTestApt 'com.google.dagger:dagger-compiler:2.6.1'
+    androidTestApt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile 'com.android.support.test:runner:0.4'
-    androidTestCompile 'com.android.support.test:rules:0.4'
+    androidTestCompile "com.android.support.test:runner:$RUNNER_VERSION"
+    androidTestCompile "com.android.support.test:rules:$RUNNER_VERSION"
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.1') {
         exclude group: 'javax.inject', module: 'javax.inject'
         exclude group: 'com.squareup', module: 'javawriter'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,12 +54,12 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
 
-    compile 'com.google.dagger:dagger:2.6.1'
+    compile "com.google.dagger:dagger:$DAGGER_VERSION"
     compile 'javax.annotation:jsr250-api:1.0'
-    apt 'com.google.dagger:dagger-compiler:2.6.1'
-    testCompile 'com.google.dagger:dagger-compiler:2.6.1'
+    apt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
+    testCompile "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
 
     testCompile project(':lib')
     androidTestCompile project(':lib')
@@ -67,14 +67,14 @@ dependencies {
     testCompile "org.robolectric:robolectric:3.0"
     testCompile 'org.assertj:assertj-core:2.5.0'
 
-    androidTestApt 'com.google.dagger:dagger-compiler:2.6.1'
+    androidTestApt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile 'com.android.support.test:runner:0.4'
-    androidTestCompile 'com.android.support.test:rules:0.4'
+    androidTestCompile "com.android.support.test:runner:$RUNNER_VERSION"
+    androidTestCompile "com.android.support.test:rules:$RUNNER_VERSION"
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.1') {
         exclude group: 'javax.inject', module: 'javax.inject'
         exclude group: 'com.squareup', module: 'javawriter'

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,7 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+## Versions
+DAGGER_VERSION = 2.7
+RUNNER_VERSION = 0.5

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,12 +26,12 @@ targetCompatibility = 1.7
 dependencies {
     compile 'org.mockito:mockito-core:1.10.19'
     compile 'junit:junit:4.12'
-    compileOnly 'com.google.dagger:dagger:2.6.1'
+    compileOnly "com.google.dagger:dagger:$DAGGER_VERSION"
 
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'junit:junit:4.12'
-    testCompile 'com.google.dagger:dagger:2.6.1'
+    testCompile "com.google.dagger:dagger:$DAGGER_VERSION"
     testCompile 'org.glassfish:javax.annotation:10.0-b28'
-    testCompile 'com.google.dagger:dagger-compiler:2.6.1'
+    testCompile "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     testCompile 'org.assertj:assertj-core:2.5.0'
 }


### PR DESCRIPTION
Updated Dagger and Runner libraries. I've also moved versions to the gradle.properties file, so it will be easier to update them in the future, as you will only have to change them in one place.