### PR TITLE
Show clear error message when trying to mock static @Provides methods

### DIFF
--- a/lib/src/main/java/it/cosenonjaviste/daggermock/ModuleOverrider.java
+++ b/lib/src/main/java/it/cosenonjaviste/daggermock/ModuleOverrider.java
@@ -31,6 +31,7 @@ import org.mockito.stubbing.Answer;
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isProtected;
 import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
 
 public class ModuleOverrider {
 
@@ -67,6 +68,7 @@ public class ModuleOverrider {
         Method[] methods = module.getClass().getDeclaredMethods();
         List<String> visibilityErrors = new ArrayList<>();
         List<String> finalErrors = new ArrayList<>();
+        List<String> staticErrors = new ArrayList<>();
         for (Method method : methods) {
             if (method.isAnnotationPresent(Provides.class)) {
                 if (!isPublic(method.getModifiers()) && !isProtected(method.getModifiers())) {
@@ -75,10 +77,14 @@ public class ModuleOverrider {
                 if (isFinal(method.getModifiers())) {
                     finalErrors.add(method.toString());
                 }
+                if (isStatic(method.getModifiers()) && overriddenObjectsMap.getProvider(method) != null) {
+                    staticErrors.add(method.toString());
+                }
             }
         }
         ErrorsFormatter.throwExceptionOnErrors("The following methods must be declared public or protected", visibilityErrors);
         ErrorsFormatter.throwExceptionOnErrors("The following methods must be non final", finalErrors);
+        ErrorsFormatter.throwExceptionOnErrors("The following methods must be non static", staticErrors);
     }
 
     public Object getValueOfClass(Class<?> type) {

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/modulemethodsvisibility/StaticMethodNotMockedTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/modulemethodsvisibility/StaticMethodNotMockedTest.java
@@ -1,0 +1,50 @@
+package it.cosenonjaviste.daggermock.modulemethodsvisibility;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import it.cosenonjaviste.daggermock.DaggerMockRule;
+
+import static org.junit.Assert.assertNotNull;
+
+public class StaticMethodNotMockedTest {
+
+    @Rule public final DaggerMockRule<MyComponent> rule = new DaggerMockRule<>(MyComponent.class, new MyModule());
+
+    @Mock MyOtherService myOtherService;
+
+    @Test
+    public void testErrorOnStaticNotMockedMethods() throws Throwable {
+        assertNotNull(myOtherService);
+    }
+
+    @Module
+    public static class MyModule {
+        @Provides public MyOtherService provideMyOtherService(MyService myService) {
+            return new MyOtherService(myService);
+        }
+
+        @Provides public static MyService provideMyService() {
+            return new MyService();
+        }
+
+        private void privateMethod() {
+        }
+    }
+
+    @Singleton
+    @Component(modules = MyModule.class)
+    public interface MyComponent {
+        MainService mainService();
+    }
+
+    public static class MyOtherService {
+        public MyOtherService(MyService myService) {}
+    }
+}

--- a/lib/src/test/java/it/cosenonjaviste/daggermock/modulemethodsvisibility/StaticMethodTest.java
+++ b/lib/src/test/java/it/cosenonjaviste/daggermock/modulemethodsvisibility/StaticMethodTest.java
@@ -1,0 +1,47 @@
+package it.cosenonjaviste.daggermock.modulemethodsvisibility;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import it.cosenonjaviste.daggermock.DaggerMockRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class StaticMethodTest {
+
+    @Mock MyService myService;
+
+    @Test
+    public void testErrorOnStaticMethods() throws Throwable {
+        try {
+            DaggerMockRule<MyComponent> rule = new DaggerMockRule<>(MyComponent.class, new MyModule());
+            rule.apply(null, null, this).evaluate();
+            fail();
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("The following methods must be non static:\n" +
+                    "public static it.cosenonjaviste.daggermock.modulemethodsvisibility.MyService it.cosenonjaviste.daggermock.modulemethodsvisibility.StaticMethodTest$MyModule.provideMyService()");
+        }
+    }
+
+    @Module
+    public static class MyModule {
+        @Provides public static MyService provideMyService() {
+            return new MyService();
+        }
+
+        private void privateMethod() {
+        }
+    }
+
+    @Singleton
+    @Component(modules = MyModule.class)
+    public interface MyComponent {
+        MainService mainService();
+    }
+}


### PR DESCRIPTION
Took me some hours to realize that you can't mock static `@Provides` methods.
Changed all my `@Provides` methods recently to static because of this [talk](https://www.youtube.com/watch?v=iwjXqRlEevg&t=307s) and couldn't figure out why my project wasn't working but the demo app was.

Thought a clear error message when trying to mock static `@Provides` methods would make sense.
Maybe should add it to `README` as well.