### PR TITLE
Added support to provide Spy dependencies

### DIFF
--- a/daggermock-kotlin/src/main/java/it/cosenonjaviste/daggermock/DaggerMock.kt
+++ b/daggermock-kotlin/src/main/java/it/cosenonjaviste/daggermock/DaggerMock.kt
@@ -37,5 +37,11 @@ class DaggerMock<C>(val rule: DaggerMockRule<C>) {
             DaggerMock<C>(rule).init()
             return rule
         }
+
+        inline fun <reified C> ruleWithSpys(spyAllUnMockedDependencies: Boolean = false, vararg modules: Any, noinline init: DaggerMock<C>.() -> Unit = {}): DaggerMockRule<C> {
+            val rule = DaggerMockRule(spyAllUnMockedDependencies, C::class.java, *modules)
+            DaggerMock<C>(rule).init()
+            return rule
+        }
     }
 }

--- a/daggermock/src/main/java/it/cosenonjaviste/daggermock/DaggerMockRule.java
+++ b/daggermock/src/main/java/it/cosenonjaviste/daggermock/DaggerMockRule.java
@@ -37,11 +37,17 @@ public class DaggerMockRule<C> implements MethodRule {
     private ComponentClassWrapper<C> componentClass;
     private ComponentSetter<C> componentSetter;
     private BuilderCustomizer customizer;
+    private boolean spyUnMockedDependencies;
     private List<Object> modules = new ArrayList<>();
     private final List<DependentComponentInfo> dependencies = new ArrayList<>();
     private final Map<Class<?>, ObjectWrapper<?>> dependenciesWrappers = new HashMap<>();
     private final Map<Class<?>, ComponentSetter<?>> dependentComponentsSetters = new HashMap<>();
     private final OverriddenObjectsMap overriddenObjectsMap = new OverriddenObjectsMap();
+
+    public DaggerMockRule(boolean spyUnMockedDependencies, Class<C> componentClass, Object... modules) {
+        this(componentClass, modules);
+        this.spyUnMockedDependencies = spyUnMockedDependencies;
+    }
 
     public DaggerMockRule(Class<C> componentClass, Object... modules) {
         this.componentClass = new ComponentClassWrapper<>(componentClass);
@@ -123,7 +129,7 @@ public class DaggerMockRule<C> implements MethodRule {
         overriddenObjectsMap.init(target);
         overriddenObjectsMap.checkOverriddenInjectAnnotatedClass(modules);
 
-        ModuleOverrider moduleOverrider = new ModuleOverrider(overriddenObjectsMap);
+        ModuleOverrider moduleOverrider = new ModuleOverrider(overriddenObjectsMap, spyUnMockedDependencies);
 
         overriddenObjectsMap.checkOverridesInSubComponentsWithNoParameters(componentClass);
 


### PR DESCRIPTION
1. Added ability to return all provided dependencies inside the module as Spies which would help with partial mocking. Fixes #81 


Note: Please let me know if you want me to update the Readme.md or if you want me to 