### PR TITLE
Replace compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,14 +450,14 @@ and the dependency in the build.gradle of the module:
 
 ```gradle
 dependencies {
-    testCompile 'com.github.fabioCollini.daggermock:daggermock:0.8.4'
+    testImplementation 'com.github.fabioCollini.daggermock:daggermock:0.8.4'
     //and/or
-    androidTestCompile 'com.github.fabioCollini.daggermock:daggermock:0.8.4'
+    androidTestImplementation 'com.github.fabioCollini.daggermock:daggermock:0.8.4'
     
     //kotlin helper methods
-    testCompile 'com.github.fabioCollini.daggermock:daggermock-kotlin:0.8.4'
+    testImplementation 'com.github.fabioCollini.daggermock:daggermock-kotlin:0.8.4'
     //and/or
-    androidTestCompile 'com.github.fabioCollini.daggermock:daggermock-kotlin:0.8.4'
+    androidTestImplementation 'com.github.fabioCollini.daggermock:daggermock-kotlin:0.8.4'
 }
 ```
 


### PR DESCRIPTION
I've replaced deprecated configurations in README.md. Configurations 'androidTestCompile' and  'testCompile' are obsolete and have been replaced with 'androidTestImplementation', 'androidTestApi', testImplementation' and 'testApi'.