### PR TITLE
Fixes bug with newest dagger version

### DIFF
--- a/RealWorldAppKotlin/build.gradle
+++ b/RealWorldAppKotlin/build.gradle
@@ -16,7 +16,9 @@
 
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
+        google()
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         applicationId "it.cosenonjaviste.daggeroverride"
-        minSdkVersion 14
+        minSdkVersion 24
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.11'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
@@ -34,6 +34,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
         google()
     }

--- a/daggermock-kotlin/build.gradle
+++ b/daggermock-kotlin/build.gradle
@@ -21,8 +21,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.fabioCollini.daggermock'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compileOnly "org.mockito:mockito-core:$MOCKITO_VERSION"
@@ -30,7 +30,7 @@ dependencies {
     compileOnly "com.google.dagger:dagger:$DAGGER_VERSION"
 
     compile project(':daggermock')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/daggermock/build.gradle
+++ b/daggermock/build.gradle
@@ -22,10 +22,11 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.fabioCollini.daggermock'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
+    compileOnly 'com.android.support:support-annotations:28.0.0'
     compileOnly "org.mockito:mockito-core:$MOCKITO_VERSION"
     compileOnly 'junit:junit:4.12'
     compileOnly "com.google.dagger:dagger:$DAGGER_VERSION"


### PR DESCRIPTION
In the newest dagger version the builder is not created with methods for setting the modules but with fields for holding the modules. 
This fix will try to look for the method and if no method with module name is found, it will search for a field named as the module. 
So every combination of dagger versions is possible.